### PR TITLE
#342: sync client remote log access

### DIFF
--- a/src/main/java/org/instedd/cdx/app/ActivationDialog.java
+++ b/src/main/java/org/instedd/cdx/app/ActivationDialog.java
@@ -19,11 +19,11 @@ import org.instedd.rsync_java_client.credentials.Credentials;
 import org.json.JSONObject;
 
 public class ActivationDialog extends JDialog {
+  private static final long serialVersionUID = 1L;
+  
   private static final Log log = LogFactory.getLog(ActivationDialog.class);
-  private CDXSettings settings;
 
-  public ActivationDialog(CDXSettings settings) {
-      this.settings = settings;
+  public ActivationDialog(final CDXSettings settings) {
       setTitle("CDX Client - Device Activation");
       setModal(true);
       setBounds(100, 100, 450, 150);

--- a/src/main/java/org/instedd/cdx/app/ActivationDialog.java
+++ b/src/main/java/org/instedd/cdx/app/ActivationDialog.java
@@ -99,6 +99,7 @@ public class ActivationDialog extends JDialog {
             settings.remoteInboxDir = serverSettings.getString("inbox_dir");
             settings.remoteOutboxDir = serverSettings.getString("outbox_dir");
             settings.deviceUUID = serverSettings.getString("device_uuid");
+            settings.deviceKey = serverSettings.getString("device_key");
 
             setVisible(false);
           } catch(Exception e) {

--- a/src/main/java/org/instedd/cdx/app/ActivationDialog.java
+++ b/src/main/java/org/instedd/cdx/app/ActivationDialog.java
@@ -98,6 +98,7 @@ public class ActivationDialog extends JDialog {
             settings.remoteUser = serverSettings.getString("user");
             settings.remoteInboxDir = serverSettings.getString("inbox_dir");
             settings.remoteOutboxDir = serverSettings.getString("outbox_dir");
+            settings.deviceUUID = serverSettings.getString("device_uuid");
 
             setVisible(false);
           } catch(Exception e) {

--- a/src/main/java/org/instedd/cdx/app/AppUpdatesMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/AppUpdatesMonitor.java
@@ -63,7 +63,7 @@ public class AppUpdatesMonitor implements RSyncApplicationMonitor {
 
 	private JSONObject latestVersion() {
 		try {
-			URL versionSource = new URL("http://" + settings.remoteHost + "/client/version.json");
+			URL versionSource = new URL(settings.authServerUrl + "/client/version.json");
 			log.debug("Checking app updates from " + versionSource.toString());
 			BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(versionSource.openStream()));
 			StringBuffer content = new StringBuffer();

--- a/src/main/java/org/instedd/cdx/app/CDXSettings.java
+++ b/src/main/java/org/instedd/cdx/app/CDXSettings.java
@@ -11,7 +11,7 @@ public class CDXSettings extends Settings {
 
   public CDXSettings() {
     super("cdx-sync-app", null);
-    authServerUrl = "http://localhost:3000";
+    authServerUrl = "http://cdp-stg.instedd.org";
     strictHostChecking = false;
   }
   

--- a/src/main/java/org/instedd/cdx/app/CDXSettings.java
+++ b/src/main/java/org/instedd/cdx/app/CDXSettings.java
@@ -1,5 +1,7 @@
 package org.instedd.cdx.app;
 
+import java.util.Properties;
+
 import org.instedd.rsync_java_client.Settings;
 
 public class CDXSettings extends Settings {
@@ -10,6 +12,25 @@ public class CDXSettings extends Settings {
     super("cdx-sync-app", null);
     authServerUrl = "http://localhost:3000";
     strictHostChecking = false;
+  }
+  
+  @Override
+  public Properties toProperties() {
+	Properties properties = super.toProperties();
+	if (authServerUrl != null) {
+		properties.setProperty("auth.server.url", authServerUrl);
+	}
+	if (deviceUUID != null) {
+		properties.setProperty("device.uuid", deviceUUID);
+	}
+	return properties;
+  }
+  
+  @Override
+  public void fromProperties(Properties properties) {
+	super.fromProperties(properties);
+	this.authServerUrl = loadProperty(properties, "auth.server.url", authServerUrl);
+	this.deviceUUID = loadProperty(properties, "device.uuid", deviceUUID);
   }
 
   public String logPath() {

--- a/src/main/java/org/instedd/cdx/app/CDXSettings.java
+++ b/src/main/java/org/instedd/cdx/app/CDXSettings.java
@@ -7,6 +7,7 @@ import org.instedd.rsync_java_client.Settings;
 public class CDXSettings extends Settings {
   public String authServerUrl;
   public String deviceUUID;
+  public String deviceKey;
 
   public CDXSettings() {
     super("cdx-sync-app", null);
@@ -14,23 +15,27 @@ public class CDXSettings extends Settings {
     strictHostChecking = false;
   }
   
-  @Override
-  public Properties toProperties() {
-	Properties properties = super.toProperties();
-	if (authServerUrl != null) {
-		properties.setProperty("auth.server.url", authServerUrl);
+	@Override
+	public Properties toProperties() {
+		Properties properties = super.toProperties();
+		if (authServerUrl != null) {
+			properties.setProperty("auth.server.url", authServerUrl);
+		}
+		if (deviceUUID != null) {
+			properties.setProperty("device.uuid", deviceUUID);
+		}
+		if (deviceKey != null) {
+			properties.setProperty("device.key", deviceKey);
+		}
+		return properties;
 	}
-	if (deviceUUID != null) {
-		properties.setProperty("device.uuid", deviceUUID);
-	}
-	return properties;
-  }
   
   @Override
   public void fromProperties(Properties properties) {
-	super.fromProperties(properties);
-	this.authServerUrl = loadProperty(properties, "auth.server.url", authServerUrl);
-	this.deviceUUID = loadProperty(properties, "device.uuid", deviceUUID);
+		super.fromProperties(properties);
+		this.authServerUrl = loadProperty(properties, "auth.server.url", authServerUrl);
+		this.deviceUUID = loadProperty(properties, "device.uuid", deviceUUID);
+		this.deviceKey = loadProperty(properties, "device.key", deviceKey);
   }
 
   public String logPath() {
@@ -41,6 +46,7 @@ public class CDXSettings extends Settings {
     super.copyTo(other);
     other.authServerUrl = this.authServerUrl;
     other.deviceUUID = this.deviceUUID;
+    other.deviceKey = this.deviceKey;
   }
 
   public CDXSettings clone() {

--- a/src/main/java/org/instedd/cdx/app/CDXSettings.java
+++ b/src/main/java/org/instedd/cdx/app/CDXSettings.java
@@ -4,10 +4,11 @@ import org.instedd.rsync_java_client.Settings;
 
 public class CDXSettings extends Settings {
   public String authServerUrl;
+  public String deviceUUID;
 
   public CDXSettings() {
     super("cdx-sync-app", null);
-    authServerUrl = "http://cdp-stg.instedd.org";
+    authServerUrl = "http://localhost:3000";
     strictHostChecking = false;
   }
 
@@ -18,6 +19,7 @@ public class CDXSettings extends Settings {
   public void copyTo(CDXSettings other) {
     super.copyTo(other);
     other.authServerUrl = this.authServerUrl;
+    other.deviceUUID = this.deviceUUID;
   }
 
   public CDXSettings clone() {

--- a/src/main/java/org/instedd/cdx/app/CommandsCheckMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/CommandsCheckMonitor.java
@@ -1,0 +1,87 @@
+package org.instedd.cdx.app;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.instedd.rsync_java_client.app.RSyncApplication;
+import org.instedd.rsync_java_client.app.RSyncApplicationMonitor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+
+public class CommandsCheckMonitor implements RSyncApplicationMonitor {
+  private static final Log log = LogFactory.getLog(AppUpdatesMonitor.class);
+  
+  private CDXSettings settings;
+  private static final long updatesCheckDelay = 5 * 60; // 5 minutes
+  private static final long updatesCheckInterval = 5 * 60 * 60 * 1000; // 1 hour
+  private Timer timer;
+
+  public CommandsCheckMonitor(CDXSettings settings) {
+    this.settings = settings;
+    timer = new Timer();
+  }
+
+  @Override
+  public void start(RSyncApplication application) {
+    timer.schedule(new TimerTask() {
+      public void run() {
+        try {
+          checkCommands();
+        } catch (Exception e) {
+          log.error("Unhandled error while checking commands", e);
+        }
+      }
+    }, updatesCheckDelay, updatesCheckInterval);
+  }
+
+  protected void checkCommands() throws Exception {
+    String deviceUUID = settings.deviceUUID;
+    String deviceKey = settings.deviceKey;
+    
+    if (deviceUUID == null || deviceKey == null)
+      return;
+    
+    String commandsURL = settings.authServerUrl + "/devices/" + settings.deviceUUID + "/device_commands?key=" + settings.deviceKey;
+    HttpResponse<JsonNode> response = Unirest.get(commandsURL).asJson();
+    if (response.getStatus() == 200) {
+       JSONArray commands = response.getBody().getArray();
+       for(int i = 0; i < commands.length(); i += 1) {
+         JSONObject command = commands.getJSONObject(i);
+         long id = command.getLong("id");
+         String commandName = command.getString("name");
+         if ("send_logs".equals(commandName)) {
+           sendLogs(id);
+         }
+       }
+    }
+  }
+
+  private void sendLogs(long id) throws Exception {
+    String logs = readLogs();
+    String commandURL = settings.authServerUrl + "/devices/" + settings.deviceUUID + "/device_commands/" + id + "/reply?key=" + settings.deviceKey;
+    Unirest.post(commandURL).body(logs).asString();
+  }
+  
+  private String readLogs() throws IOException {
+    BufferedReader reader = new BufferedReader(new FileReader(settings.logPath()));
+    try {
+      StringBuffer content = new StringBuffer();
+      String line = null;
+      while ((line = reader.readLine()) != null) {
+        content.append(line);
+      }
+      return content.toString();
+    } finally {
+      reader.close();
+    }
+  }
+}

--- a/src/main/java/org/instedd/cdx/app/CommandsCheckMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/CommandsCheckMonitor.java
@@ -21,8 +21,8 @@ public class CommandsCheckMonitor implements RSyncApplicationMonitor {
   private static final Log log = LogFactory.getLog(AppUpdatesMonitor.class);
   
   private CDXSettings settings;
-  private static final long updatesCheckDelay = 5 * 60; // 5 minutes
-  private static final long updatesCheckInterval = 5 * 60 * 60 * 1000; // 1 hour
+  private static final long updatesCheckDelay = 5 * 60 * 1000; // 5 minutes
+  private static final long updatesCheckInterval = 1 * 60 * 60 * 1000; // 1 hour
   private Timer timer;
 
   public CommandsCheckMonitor(CDXSettings settings) {

--- a/src/main/java/org/instedd/cdx/app/Main.java
+++ b/src/main/java/org/instedd/cdx/app/Main.java
@@ -74,6 +74,7 @@ public class Main {
     app.addMonitor(new SystemTrayMonitor(settings));
     app.addMonitor(new ConsoleMonitor());
     app.addMonitor(new AppUpdatesMonitor(settings, app));
+    app.addMonitor(new CommandsCheckMonitor(settings));
     app.start();
   }
 

--- a/src/main/java/org/instedd/cdx/app/SettingsDialog.java
+++ b/src/main/java/org/instedd/cdx/app/SettingsDialog.java
@@ -1,12 +1,9 @@
 package org.instedd.cdx.app;
 
-import java.io.IOException;
-
 import java.awt.Container;
 import java.awt.Font;
+import java.io.IOException;
 
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.GroupLayout;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -16,9 +13,12 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.SwingConstants;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 public class SettingsDialog extends JDialog {
-  private CDXSettings originalSettings;
+  private static final long serialVersionUID = 1L;
+  
   private CDXSettings settings;
   private JTextField outboxTextField;
   private JButton activationButton;
@@ -27,7 +27,6 @@ public class SettingsDialog extends JDialog {
   private boolean cancelled;
 
   public SettingsDialog(CDXSettings originalSettings) {
-    this.originalSettings = originalSettings;
     this.settings = originalSettings.clone();
     setTitle("CDX Client - Settings");
     setModal(true);

--- a/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
@@ -143,7 +143,7 @@ public class SystemTrayMonitor extends org.instedd.rsync_java_client.app.SystemT
 		String deviceUUID = settings.deviceUUID;
 		if (deviceUUID == null) return;
 	
-		String url = settings.authServerUrl + "/devices/" + deviceUUID + "/submit_log";
+		String url = settings.authServerUrl + "/devices/" + deviceUUID + "/device_logs";
 		try {
 			Unirest.post(url).body(string).asString();
 		} catch (UnirestException e) {

--- a/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
@@ -18,7 +18,6 @@ import org.instedd.rsync_java_client.app.RSyncApplication;
 
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import com.sun.org.apache.xerces.internal.util.URI;
 
 public class SystemTrayMonitor extends org.instedd.rsync_java_client.app.SystemTrayMonitor
   implements RsyncSynchronizerListener {

--- a/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
+++ b/src/main/java/org/instedd/cdx/app/SystemTrayMonitor.java
@@ -18,6 +18,7 @@ import org.instedd.rsync_java_client.app.RSyncApplication;
 
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import com.sun.org.apache.xerces.internal.util.URI;
 
 public class SystemTrayMonitor extends org.instedd.rsync_java_client.app.SystemTrayMonitor
   implements RsyncSynchronizerListener {
@@ -143,7 +144,7 @@ public class SystemTrayMonitor extends org.instedd.rsync_java_client.app.SystemT
 		String deviceUUID = settings.deviceUUID;
 		if (deviceUUID == null) return;
 	
-		String url = settings.authServerUrl + "/devices/" + deviceUUID + "/device_logs";
+		String url = settings.authServerUrl + "/devices/" + deviceUUID + "/device_logs?key=" + settings.deviceKey;
 		try {
 			Unirest.post(url).body(string).asString();
 		} catch (UnirestException e) {


### PR DESCRIPTION
This is the client side of https://github.com/instedd/cdx/pull/373
- When an error is found when doing an rsync, try to immediately send logs to the server. In case of failure, a popup with an error message is shown (maybe something different should be done here)
- Periodically (every hour) check for server commands. When found, immediately process them. Right now the only support command is "send_logs". Maybe we could send this to a queue, but I don't know, POSTing data should be fast, and if that fails then in the next hours it'll try to send them again, etc.
